### PR TITLE
filter: Fix filter key format

### DIFF
--- a/frontend/src/lib/components/params/filter.svelte
+++ b/frontend/src/lib/components/params/filter.svelte
@@ -64,7 +64,7 @@
 				<select class="col-start-1 row-start-1 pl-3 pr-8 appearance-none p-1.5 rounded bg-gray-800"
 								bind:value={filter.key}>
 					{#each fields as field}
-						<option>{field.ds}.{field.fullName}</option>
+						<option>{field.ds}:{field.fullName}</option>
 					{/each}
 				</select>
 			</div>


### PR DESCRIPTION
Currently when filtering for field we get following error:

![image](https://github.com/user-attachments/assets/5c134db1-b93e-47dc-a69e-4933239a5c80)


It seems the filter key is prefixed with `dns.` and `dns:`, a datasource should be prefixed with `:`. This change fixes the issue. 

## Testing Done

Filtering works fine after this change

```
$  sudo ig run trace_dns --host --filter dns:qr==R
RUNTIME.CONTAINERNAME                          SRC                                                  DST                                                  COMM                    PID        TID QR   QTYPE                    NAME                                          RCODE        ADDRESSES                                    LATENCY_NS
                                               192.168.0.28:5353                                    224.0.0.251:5353                                     avahi-daemon            938        938 R                                                                           Success                                                          0ns
                                               2a02:8108:c01:3700:6833:b0b7:92d7:f38e:5353          ff02::fb:5353                                        avahi-daemon            938        938 R                                                                           Success                                                          0ns
                                               fe80::4627:45ff:fed6:45de:5353                       ff02::fb:5353                                        avahi-daemon            938        938 R                                                                           Success                                                          0ns
```

```
$ sudo ig run trace_dns --host --filter dns.qr==R
Error: initializing and preparing operators: instantiating operator "filter": field "dns.qr" not found

```